### PR TITLE
Add support for resource collection serialization

### DIFF
--- a/lib/json_api_object_serializer/serialization.rb
+++ b/lib/json_api_object_serializer/serialization.rb
@@ -6,19 +6,35 @@ module JsonApiObjectSerializer
       base.extend DSL
     end
 
-    def to_hash(resource)
-      resource_hash(resource)
+    def to_hash(resource, **options)
+      if options[:collection]
+        serialized_collection(resource, **options)
+      else
+        serialized_hash(resource, **options)
+      end
     end
 
     private
 
-    def resource_hash(resource)
+    def serialized_hash(resource, **_options)
       result_hash = { data: nil }
+
+      return result_hash if resource.nil?
+
       result_hash[:data] = identifier_of(resource)
       result_hash[:data].merge!(attributes_from(resource))
       result_hash[:data].merge!(relationships_from(resource))
 
       result_hash
+    end
+
+    def serialized_collection(resource_collection, **_options)
+      return { data: [] } if resource_collection.nil?
+
+      resource_collection.each_with_object(data: []) do |resource, result_hash|
+        serialized_resource_hash = serialized_hash(resource)[:data]
+        result_hash[:data].push(serialized_resource_hash) unless serialized_resource_hash.nil?
+      end
     end
 
     def identifier_of(resource)

--- a/spec/integration/empty_resources_spec.rb
+++ b/spec/integration/empty_resources_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe "Empty resources", type: :integration do
+  subject(:serializer) do
+    Class.new do
+      include JsonApiObjectSerializer
+
+      type "foos"
+      attributes :foo, :bar
+    end
+  end
+
+  context "without the collection option" do
+    context "when the resource is nil" do
+      it "returns the correct empty serialized hash for single resource" do
+        result = serializer.to_hash(nil)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to eq data: nil
+        end
+      end
+    end
+  end
+
+  context "with the collection option" do
+    context "with empty collection" do
+      it "returns the correct empty serialized hash for resource collection" do
+        result = serializer.to_hash([], collection: true)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to eq data: []
+        end
+      end
+    end
+
+    context "with collection with only nil" do
+      it "returns the correct empty serialized hash for resource collection" do
+        result = serializer.to_hash([nil, nil, nil], collection: true)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to eq data: []
+        end
+      end
+    end
+
+    context "with nil collection" do
+      it "returns the correct empty serialized hash for resource collection" do
+        result = serializer.to_hash(nil, collection: true)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to eq data: []
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/resource_collection_spec.rb
+++ b/spec/integration/resource_collection_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "Resource collection", type: :integration do
+  subject(:serializer) do
+    Class.new do
+      include JsonApiObjectSerializer
+
+      type "foos"
+      attributes :foo, :bar
+    end
+  end
+
+  it "serializes the collection correctly" do
+    resource1 = double(:resource1, id: 1, foo: "Foo", bar: "Bar")
+    resource2 = double(:resource2, id: 2, foo: "Fus", bar: "RO-DAH")
+
+    result = serializer.to_hash([resource1, resource2], collection: true)
+
+    aggregate_failures do
+      expect(result).to match_jsonapi_schema
+      expect(result).to match(
+        data: contain_exactly(
+          { type: "foos", id: "1", attributes: { foo: "Foo", bar: "Bar" } },
+          type: "foos", id: "2", attributes: { foo: "Fus", bar: "RO-DAH" }
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Adds new option for serialization methods to identify if it is a collection or not (`collection: true`)
- Adds verifications to return the correct empty serialized hash for `nil` values and empty collections

Closes https://github.com/absaldanha/json_api_object_serializer/issues/15