### PR TITLE
Add initial support for sparse fieldsets

### DIFF
--- a/lib/json_api_object_serializer.rb
+++ b/lib/json_api_object_serializer.rb
@@ -2,6 +2,8 @@
 
 require "json_api_object_serializer/version"
 require "json_api_object_serializer/serialized_name"
+require "json_api_object_serializer/null_fieldset"
+require "json_api_object_serializer/fieldset"
 require "json_api_object_serializer/identifier"
 require "json_api_object_serializer/attribute_collection"
 require "json_api_object_serializer/relationship_collection"

--- a/lib/json_api_object_serializer/attribute_collection.rb
+++ b/lib/json_api_object_serializer/attribute_collection.rb
@@ -17,8 +17,8 @@ module JsonApiObjectSerializer
       attributes.add(attribute)
     end
 
-    def serialize(resource)
-      attributes.inject({}) do |hash, attribute|
+    def serialize(resource, fieldset: NullFieldset.new)
+      attributes_from(fieldset).inject({}) do |hash, attribute|
         hash.merge(attribute.serialize(resource))
       end
     end
@@ -26,5 +26,9 @@ module JsonApiObjectSerializer
     private
 
     attr_reader :attributes
+
+    def attributes_from(fieldset)
+      attributes.select { |attribute| fieldset.include?(attribute.serialized_name) }
+    end
   end
 end

--- a/lib/json_api_object_serializer/fieldset.rb
+++ b/lib/json_api_object_serializer/fieldset.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "set"
+require "forwardable"
+
+module JsonApiObjectSerializer
+  class Fieldset
+    extend Forwardable
+
+    attr_reader :fields, :type
+    def_delegators :fields, :include?
+
+    def self.build(type, fields = {})
+      type_fields = fields[type.to_sym]
+
+      type_fields.nil? ? NullFieldset.new : new(type_fields, type)
+    end
+
+    def initialize(fields, type)
+      @type = type
+      @fields = Set.new(fields)
+    end
+  end
+end

--- a/lib/json_api_object_serializer/null_fieldset.rb
+++ b/lib/json_api_object_serializer/null_fieldset.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module JsonApiObjectSerializer
+  class NullFieldset
+    def include?(_field)
+      true
+    end
+  end
+end

--- a/lib/json_api_object_serializer/relationship_collection.rb
+++ b/lib/json_api_object_serializer/relationship_collection.rb
@@ -17,8 +17,8 @@ module JsonApiObjectSerializer
       relationships.add(relationship)
     end
 
-    def serialize(resource_object)
-      relationships.inject({}) do |hash, relationship|
+    def serialize(resource_object, fieldset: NullFieldset.new)
+      relationships_from(fieldset).inject({}) do |hash, relationship|
         hash.merge(relationship.serialize(resource_object))
       end
     end
@@ -26,5 +26,9 @@ module JsonApiObjectSerializer
     private
 
     attr_reader :relationships
+
+    def relationships_from(fieldset)
+      relationships.select { |relationship| fieldset.include?(relationship.serialized_name) }
+    end
   end
 end

--- a/lib/json_api_object_serializer/serialization.rb
+++ b/lib/json_api_object_serializer/serialization.rb
@@ -7,11 +7,13 @@ module JsonApiObjectSerializer
     end
 
     def to_hash(resource, **options)
+      fieldset = Fieldset.build(identifier.type, options.fetch(:fields, {}))
+
       data =
         if options[:collection]
-          serialized_collection(resource, **options)
+          serialized_collection(resource, fieldset: fieldset)
         else
-          serialized_hash(resource, **options)
+          serialized_hash(resource, fieldset: fieldset)
         end
 
       { data: data }
@@ -19,17 +21,17 @@ module JsonApiObjectSerializer
 
     private
 
-    def serialized_hash(resource, **_options)
+    def serialized_hash(resource, fieldset:)
       return unless resource
 
       identifier_of(resource)
-        .merge(attributes_from(resource))
-        .merge(relationships_from(resource))
+        .merge(attributes_from(resource, fieldset: fieldset))
+        .merge(relationships_from(resource, fieldset: fieldset))
     end
 
-    def serialized_collection(resource_collection, **_options)
+    def serialized_collection(resource_collection, fieldset:)
       Array(resource_collection)
-        .map { |resource| serialized_hash(resource) }
+        .map { |resource| serialized_hash(resource, fieldset: fieldset) }
         .compact
     end
 
@@ -37,18 +39,16 @@ module JsonApiObjectSerializer
       identifier.serialize(resource)
     end
 
-    def attributes_from(resource)
-      { attributes: resource_attributes_from(resource) }
+    def attributes_from(resource, fieldset:)
+      attributes = attribute_collection.serialize(resource, fieldset: fieldset)
+      attributes.empty? ? {} : { attributes: attributes }
     end
 
-    def relationships_from(resource)
+    def relationships_from(resource, fieldset:)
       return {} if relationship_collection.empty?
 
-      { relationships: relationship_collection.serialize(resource) }
-    end
-
-    def resource_attributes_from(resource)
-      attribute_collection.serialize(resource)
+      relationships = relationship_collection.serialize(resource, fieldset: fieldset)
+      relationships.empty? ? {} : { relationships: relationships }
     end
   end
 end

--- a/spec/integration/sparse_fieldsets_spec.rb
+++ b/spec/integration/sparse_fieldsets_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "Sparse fieldsets", type: :integration do
+  subject(:serializer) do
+    Class.new do
+      include JsonApiObjectSerializer
+
+      type "foos"
+      attributes :foo, :bar
+      has_one :buz, type: "buzes"
+    end
+  end
+
+  it "serializes the resource correctly with only the specified attributes" do
+    buz_relationship = double(:buz_relationship, id: 1)
+    resource = double(:resource, id: 1, foo: "Foo", bar: "Bar", buz: buz_relationship)
+
+    result = serializer.to_hash(resource, fields: { foos: [:foo] })
+
+    aggregate_failures do
+      expect(result).to match_jsonapi_schema
+      expect(result).to match data: { id: "1", type: "foos", attributes: { foo: "Foo" } }
+    end
+  end
+end

--- a/spec/json_api_object_serializer/attribute_collection_spec.rb
+++ b/spec/json_api_object_serializer/attribute_collection_spec.rb
@@ -24,23 +24,54 @@ RSpec.describe JsonApiObjectSerializer::AttributeCollection do
     end
   end
 
-  describe "#serialized" do
-    it "returns the serialized hash of attributes of the given resource object" do
-      resource = double(:resource)
-      first_name_attribute = instance_double(
-        JsonApiObjectSerializer::Attribute, serialize: { "first-name": "Alexandre" }
-      )
-      last_name_attribute = instance_double(
-        JsonApiObjectSerializer::Attribute,
-        serialize: { "last-name": "Saldanha" }
-      )
+  describe "#serialize" do
+    context "with no field restriction" do
+      it "returns the serialized hash of all attributes of the given resource object" do
+        resource = double(:resource)
+        first_name_attribute = instance_double(
+          JsonApiObjectSerializer::Attribute,
+          serialized_name: :"first-name",
+          serialize: { "first-name": "Alexandre" }
+        )
+        last_name_attribute = instance_double(
+          JsonApiObjectSerializer::Attribute,
+          serialized_name: :"last-name",
+          serialize: { "last-name": "Saldanha" }
+        )
 
-      attribute_collection.add(first_name_attribute)
-      attribute_collection.add(last_name_attribute)
+        attribute_collection.add(first_name_attribute)
+        attribute_collection.add(last_name_attribute)
 
-      expect(attribute_collection.serialize(resource)).to match(
-        "first-name": "Alexandre", "last-name": "Saldanha"
-      )
+        expect(attribute_collection.serialize(resource)).to match(
+          "first-name": "Alexandre", "last-name": "Saldanha"
+        )
+      end
+    end
+
+    context "with field restriction" do
+      it "returns the serialized hash of the specified attributes of the given resource object" do
+        resource = double(:resource)
+        fieldset = instance_double(JsonApiObjectSerializer::Fieldset)
+        first_name_attribute = instance_double(
+          JsonApiObjectSerializer::Attribute,
+          serialize: { "first-name": "Alexandre" },
+          serialized_name: :"first-name"
+        )
+        last_name_attribute = instance_double(
+          JsonApiObjectSerializer::Attribute,
+          serialized_name: :"last-name"
+        )
+
+        allow(fieldset).to receive(:include?).with(:"first-name").and_return(true)
+        allow(fieldset).to receive(:include?).with(:"last-name").and_return(false)
+
+        attribute_collection.add(first_name_attribute)
+        attribute_collection.add(last_name_attribute)
+
+        expect(attribute_collection.serialize(resource, fieldset: fieldset)).to match(
+          "first-name": "Alexandre"
+        )
+      end
     end
   end
 end

--- a/spec/json_api_object_serializer/fieldset_spec.rb
+++ b/spec/json_api_object_serializer/fieldset_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiObjectSerializer::Fieldset do
+  describe ".build" do
+    context "when the given type has no specified fields" do
+      it "returns a NullFieldset" do
+        expect(JsonApiObjectSerializer::Fieldset.build("foo", bar: %i[fuz buz])).to(
+          be_an_instance_of(JsonApiObjectSerializer::NullFieldset)
+        )
+      end
+    end
+
+    context "when the given type has specified fields" do
+      it "returns a Fieldset" do
+        expect(JsonApiObjectSerializer::Fieldset.build("foo", foo: %i[bar baz])).to(
+          be_an_instance_of(JsonApiObjectSerializer::Fieldset)
+        )
+      end
+    end
+  end
+end

--- a/spec/json_api_object_serializer/null_fieldset_spec.rb
+++ b/spec/json_api_object_serializer/null_fieldset_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiObjectSerializer::NullFieldset do
+  subject(:null_fieldset) { JsonApiObjectSerializer::NullFieldset.new }
+
+  describe "#include?" do
+    it "always returns true" do
+      expect(null_fieldset.include?(:bar)).to be true
+      expect(null_fieldset.include?(:foo)).to be true
+    end
+  end
+end

--- a/spec/json_api_object_serializer/relationship_collection_spec.rb
+++ b/spec/json_api_object_serializer/relationship_collection_spec.rb
@@ -27,30 +27,60 @@ RSpec.describe JsonApiObjectSerializer::RelationshipCollection do
   end
 
   describe "#serialize" do
-    it "returns the serialized hash of relationships of the given resource object" do
-      resource = double(:resource)
-      address_relationship = instance_double(
-        JsonApiObjectSerializer::Relationships::Base,
-        serialize: { address: { data: { id: "address_id", type: "addresses" } } }
-      )
-      tasks_relationship = instance_double(
-        JsonApiObjectSerializer::Relationships::Base,
-        serialize: { tasks: { data: [
-          { id: "task_id_1", type: "tasks" }, { id: "task_id_2", type: "tasks" }
-        ] } }
-      )
-
-      relationship_collection.add(address_relationship)
-      relationship_collection.add(tasks_relationship)
-
-      expect(relationship_collection.serialize(resource)).to eq(
-        address: { data: { id: "address_id", type: "addresses" } },
-        tasks: {
-          data: [
+    context "with no field restrictions" do
+      it "returns the serialized hash of all relationships of the given resource object" do
+        resource = double(:resource)
+        address_relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          serialized_name: :address,
+          serialize: { address: { data: { id: "address_id", type: "addresses" } } }
+        )
+        tasks_relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          serialized_name: :tasks,
+          serialize: { tasks: { data: [
             { id: "task_id_1", type: "tasks" }, { id: "task_id_2", type: "tasks" }
-          ]
-        }
-      )
+          ] } }
+        )
+
+        relationship_collection.add(address_relationship)
+        relationship_collection.add(tasks_relationship)
+
+        expect(relationship_collection.serialize(resource)).to eq(
+          address: { data: { id: "address_id", type: "addresses" } },
+          tasks: {
+            data: [
+              { id: "task_id_1", type: "tasks" }, { id: "task_id_2", type: "tasks" }
+            ]
+          }
+        )
+      end
+    end
+
+    context "with field restrictions" do
+      it "returns the serialized hash of specified relationships of the given resource object" do
+        resource = double(:resource)
+        fieldset = instance_double(JsonApiObjectSerializer::Fieldset)
+        address_relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          serialize: { address: { data: { id: "address_id", type: "addresses" } } },
+          serialized_name: :address
+        )
+        tasks_relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          serialized_name: :tasks
+        )
+
+        allow(fieldset).to receive(:include?).with(:address).and_return(true)
+        allow(fieldset).to receive(:include?).with(:tasks).and_return(false)
+
+        relationship_collection.add(address_relationship)
+        relationship_collection.add(tasks_relationship)
+
+        expect(relationship_collection.serialize(resource, fieldset: fieldset)).to eq(
+          address: { data: { id: "address_id", type: "addresses" } }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- Adds new option to serialization methods so users can specify fields to include
- Modifies collection classes (`AttributeCollection` and `RelationshipCollection`) to serialize only specified elements