### PR TITLE
Add new option for customizing relationship id method

### DIFF
--- a/lib/json_api_object_serializer/dsl.rb
+++ b/lib/json_api_object_serializer/dsl.rb
@@ -5,8 +5,6 @@ module JsonApiObjectSerializer
     def self.extended(base)
       base.class_eval do
         singleton_class.class_eval do
-          private
-
           attr_accessor :attribute_collection, :relationship_collection, :identifier
         end
 

--- a/lib/json_api_object_serializer/identifier.rb
+++ b/lib/json_api_object_serializer/identifier.rb
@@ -5,7 +5,7 @@ module JsonApiObjectSerializer
     attr_reader :id, :type
 
     def initialize(id: nil, type: nil)
-      @id = id || proc { |resource| resource.id }
+      @id = callable_id(id) || proc { |resource| resource.id }
       @type = type
     end
 
@@ -18,7 +18,15 @@ module JsonApiObjectSerializer
     end
 
     def id=(custom_id)
-      @id = custom_id.to_proc
+      @id = callable_id(custom_id)
+    end
+
+    private
+
+    def callable_id(id)
+      return unless id
+
+      id.to_proc
     end
   end
 end

--- a/lib/json_api_object_serializer/relationships/base.rb
+++ b/lib/json_api_object_serializer/relationships/base.rb
@@ -10,7 +10,7 @@ module JsonApiObjectSerializer
       def initialize(name:, type:, **options)
         @name = name
         @type = type
-        @identifier = Identifier.new(type: type)
+        @identifier = Identifier.new(id: options[:id], type: type)
         @options = options
       end
 

--- a/spec/integration/relationships/has_one_spec.rb
+++ b/spec/integration/relationships/has_one_spec.rb
@@ -62,4 +62,66 @@ RSpec.describe "Has one relationship", type: :integration do
       end
     end
   end
+
+  context "with custom id" do
+    context "with method name" do
+      subject(:serializer) do
+        Class.new do
+          include JsonApiObjectSerializer
+
+          type "foos"
+          attributes :foo, :bar
+          has_one :baz, type: "bazes", id: :uuid
+        end
+      end
+
+      it "serializes the resource correctly with the custom relationship id method" do
+        baz_relationship = double(:baz, uuid: "uuid-1")
+        resource = double(:resource, id: 1, foo: "Foo", bar: "Bar", baz: baz_relationship)
+
+        result = serializer.to_hash(resource)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to match(
+            data: a_hash_including(
+              relationships: a_hash_including(
+                baz: { data: { type: "bazes", id: "uuid-1" } }
+              )
+            )
+          )
+        end
+      end
+    end
+
+    context "with proc" do
+      subject(:serializer) do
+        Class.new do
+          include JsonApiObjectSerializer
+
+          type "foos"
+          attributes :foo, :bar
+          has_one :baz, type: "bazes", id: ->(resource) { "unique-id-#{resource.id}" }
+        end
+      end
+
+      it "serializes the resource correctly with the custom relationship id method" do
+        baz_relationship = double(:baz, id: 1)
+        resource = double(:resource, id: 1, foo: "Foo", bar: "Bar", baz: baz_relationship)
+
+        result = serializer.to_hash(resource)
+
+        aggregate_failures do
+          expect(result).to match_jsonapi_schema
+          expect(result).to match(
+            data: a_hash_including(
+              relationships: a_hash_including(
+                baz: { data: { type: "bazes", id: "unique-id-1" } }
+              )
+            )
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Adds new `id` option when declaring a relationship, that works just like the high level `id` method