### PR TITLE
Add support for meta declaration

### DIFF
--- a/lib/json_api_object_serializer.rb
+++ b/lib/json_api_object_serializer.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "json_api_object_serializer/version"
+require "json_api_object_serializer/core_ext"
+require "json_api_object_serializer/key_serialization"
 require "json_api_object_serializer/serialized_name"
+require "json_api_object_serializer/meta"
 require "json_api_object_serializer/null_fieldset"
 require "json_api_object_serializer/fieldset"
 require "json_api_object_serializer/identifier"

--- a/lib/json_api_object_serializer/core_ext.rb
+++ b/lib/json_api_object_serializer/core_ext.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "json_api_object_serializer/core_ext/hashes"
+
+module JsonApiObjectSerializer
+  module CoreExt
+  end
+end

--- a/lib/json_api_object_serializer/core_ext/hashes.rb
+++ b/lib/json_api_object_serializer/core_ext/hashes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module JsonApiObjectSerializer
+  module CoreExt
+    module Hashes
+      refine Hash do
+        def deep_transform_keys(&blk)
+          each_with_object({}) do |(key, value), output|
+            output[yield(key)] =
+              case value
+              when Hash then value.deep_transform_keys(&blk)
+              when Array
+                value.map { |item| item.is_a?(Hash) ? item.deep_transform_keys(&blk) : item }
+              else
+                value
+              end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_object_serializer/dsl.rb
+++ b/lib/json_api_object_serializer/dsl.rb
@@ -5,12 +5,13 @@ module JsonApiObjectSerializer
     def self.extended(base)
       base.class_eval do
         singleton_class.class_eval do
-          attr_accessor :attribute_collection, :relationship_collection, :identifier
+          attr_accessor :attribute_collection, :relationship_collection, :identifier, :meta_object
         end
 
         self.attribute_collection = AttributeCollection.new
         self.relationship_collection = RelationshipCollection.new
         self.identifier = Identifier.new
+        self.meta_object = Meta.new
       end
     end
 
@@ -36,6 +37,10 @@ module JsonApiObjectSerializer
 
     def has_many(name, type:, **options)
       relationship_collection.add(Relationships.has_many(name: name, type: type, **options))
+    end
+
+    def meta(hash = {})
+      meta_object.add(hash)
     end
   end
 end

--- a/lib/json_api_object_serializer/key_serialization.rb
+++ b/lib/json_api_object_serializer/key_serialization.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module JsonApiObjectSerializer
+  module KeySerialization
+    def serialized_key(key)
+      key.to_s.tr("_", "-").to_sym
+    end
+  end
+end

--- a/lib/json_api_object_serializer/meta.rb
+++ b/lib/json_api_object_serializer/meta.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module JsonApiObjectSerializer
+  class Meta
+    include KeySerialization
+    using CoreExt::Hashes
+    extend Forwardable
+
+    def_delegators :hash, :empty?
+
+    attr_reader :hash
+
+    def initialize
+      @hash = {}
+    end
+
+    def serialize
+      hash.deep_transform_keys { |key| serialized_key(key) }
+    end
+
+    def add(other_hash = {})
+      hash.merge!(other_hash)
+    end
+  end
+end

--- a/lib/json_api_object_serializer/serialization.rb
+++ b/lib/json_api_object_serializer/serialization.rb
@@ -10,7 +10,8 @@ module JsonApiObjectSerializer
       fieldset = Fieldset.build(identifier.type, options.fetch(:fields, {}))
       included = build_included_resources(options.fetch(:include, []))
 
-      serialized_data(resource, fieldset: fieldset, collection: options[:collection])
+      serialized_meta
+        .merge(serialized_data(resource, fieldset: fieldset, collection: options[:collection]))
         .merge(serialized_included(resource, fieldset: fieldset, included: included))
     end
 
@@ -23,6 +24,12 @@ module JsonApiObjectSerializer
           included_resource_collection.add(IncludedResource.new(relationship))
         end
       end
+    end
+
+    def serialized_meta
+      return {} if meta_object.empty?
+
+      { meta: meta_object.serialize }
     end
 
     def serialized_data(resource, fieldset:, collection:)

--- a/lib/json_api_object_serializer/serialized_name.rb
+++ b/lib/json_api_object_serializer/serialized_name.rb
@@ -2,14 +2,10 @@
 
 module JsonApiObjectSerializer
   module SerializedName
+    include KeySerialization
+
     def serialized_name
-      @serialized_name ||= name_formating(options[:as] || name).to_sym
-    end
-
-    private
-
-    def name_formating(string)
-      string.to_s.tr("_", "-")
+      @serialized_name ||= serialized_key(options[:as] || name)
     end
   end
 end

--- a/spec/integration/with_meta_spec.rb
+++ b/spec/integration/with_meta_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe "Top level meta", type: :integration do
+  subject(:serializer) do
+    Class.new do
+      include JsonApiObjectSerializer
+
+      meta copyright: "Foo Copyright", authors: ["Alexandre Saldanha", "Foo Author"],
+           related_meta: { fuz: "Fuz", baz: "Baz" }
+
+      type "foos"
+      attribute :foo
+    end
+  end
+
+  it "renders the correct resource hash with the specified meta object" do
+    resource = double(:resource, id: 1, foo: "Foo")
+
+    result = serializer.to_hash(resource)
+
+    aggregate_failures do
+      expect(result).to match_jsonapi_schema
+      expect(result).to match(
+        a_hash_including(
+          meta: a_hash_including(
+            copyright: "Foo Copyright", authors: ["Alexandre Saldanha", "Foo Author"],
+            "related-meta": { fuz: "Fuz", baz: "Baz" }
+          )
+        )
+      )
+    end
+  end
+end

--- a/spec/json_api_object_serializer/core_ext/hashes_spec.rb
+++ b/spec/json_api_object_serializer/core_ext/hashes_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiObjectSerializer::CoreExt::Hashes do
+  using JsonApiObjectSerializer::CoreExt::Hashes
+
+  describe "#deep_transform_keys" do
+    it "transform keys on shallow hashes" do
+      hash = { "a" => 1, "b" => 2 }
+
+      expect(hash.deep_transform_keys(&:to_sym)).to eq(a: 1, b: 2)
+    end
+
+    it "transform keys on hashes within other hashes" do
+      hash = { a: 1, b: { c: 2 } }
+      result = hash.deep_transform_keys { |key| "#{key}-foo" }
+
+      expect(result).to eq("a-foo" => 1, "b-foo" => { "c-foo" => 2 })
+    end
+
+    it "transform keys on hashes within arrays" do
+      hash = { "a" => 1, b: { "c" => [{ d: 3 }, { "e" => 4 }] } }
+      result = hash.deep_transform_keys(&:to_sym)
+
+      expect(result).to eq(a: 1, b: { c: [{ d: 3 }, { e: 4 }] })
+    end
+  end
+end

--- a/spec/json_api_object_serializer/key_serialization_spec.rb
+++ b/spec/json_api_object_serializer/key_serialization_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiObjectSerializer::KeySerialization do
+  describe "#serialized_key" do
+    subject do
+      Class.new do
+        include JsonApiObjectSerializer::KeySerialization
+      end.new
+    end
+
+    it "transforms the key correctly" do
+      expect(subject.serialized_key(:foo_bar)).to eq :"foo-bar"
+    end
+  end
+end

--- a/spec/json_api_object_serializer/meta_spec.rb
+++ b/spec/json_api_object_serializer/meta_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonApiObjectSerializer::Meta do
+  subject(:meta) { JsonApiObjectSerializer::Meta.new }
+
+  describe "#add" do
+    it "adds the contents of the hash in the meta object" do
+      meta.add(foo: "foo", bar: "bar")
+
+      expect(meta.hash).to eq(foo: "foo", bar: "bar")
+    end
+  end
+
+  describe "#serialize" do
+    it "returns the serialized inner hash" do
+      meta.add(foo: "foo", fuz_bar: "fuz-bar", bar: { "fuz" => "fuz" })
+      expect(meta.serialize).to eq(foo: "foo", "fuz-bar": "fuz-bar", bar: { fuz: "fuz" })
+    end
+  end
+end


### PR DESCRIPTION
- Adds new DSL method `meta` for declaration of meta attributes
- Extracts key serialization to a module so it can be used across all classes that includes it, not just classes including `SerializedName`