### PR TITLE
Add support for relationship links

### DIFF
--- a/lib/json_api_object_serializer/dsl.rb
+++ b/lib/json_api_object_serializer/dsl.rb
@@ -35,12 +35,12 @@ module JsonApiObjectSerializer
       names.each { |name| attribute(name) }
     end
 
-    def has_one(name, type:, **options)
-      relationship_collection.add(Relationships.has_one(name: name, type: type, **options))
+    def has_one(name, type:, **options, &block)
+      relationship_collection.add(Relationships.has_one(name: name, type: type, **options, &block))
     end
 
-    def has_many(name, type:, **options)
-      relationship_collection.add(Relationships.has_many(name: name, type: type, **options))
+    def has_many(name, type:, **options, &block)
+      relationship_collection.add(Relationships.has_many(name: name, type: type, **options, &block))
     end
 
     def meta(hash = {})

--- a/lib/json_api_object_serializer/link_collection.rb
+++ b/lib/json_api_object_serializer/link_collection.rb
@@ -14,9 +14,11 @@ module JsonApiObjectSerializer
     end
 
     def serialize(resource)
-      links.inject({}) do |hash, link|
+      links_hash = links.inject({}) do |hash, link|
         hash.merge(link.serialize(resource))
       end
+
+      { links: links_hash }
     end
 
     private

--- a/lib/json_api_object_serializer/null_link_collection.rb
+++ b/lib/json_api_object_serializer/null_link_collection.rb
@@ -5,5 +5,9 @@ module JsonApiObjectSerializer
     def empty?
       true
     end
+
+    def serialize(_resource)
+      {}
+    end
   end
 end

--- a/lib/json_api_object_serializer/relationships.rb
+++ b/lib/json_api_object_serializer/relationships.rb
@@ -6,12 +6,12 @@ require "json_api_object_serializer/relationships/has_many"
 
 module JsonApiObjectSerializer
   module Relationships
-    def self.has_one(name:, type:, **options)
-      HasOne.new(name: name, type: type, **options)
+    def self.has_one(name:, type:, **options, &block)
+      HasOne.new(name: name, type: type, **options, &block)
     end
 
-    def self.has_many(name:, type:, **options)
-      HasMany.new(name: name, type: type, **options)
+    def self.has_many(name:, type:, **options, &block)
+      HasMany.new(name: name, type: type, **options, &block)
     end
   end
 end

--- a/lib/json_api_object_serializer/relationships/has_many.rb
+++ b/lib/json_api_object_serializer/relationships/has_many.rb
@@ -3,13 +3,11 @@
 module JsonApiObjectSerializer
   module Relationships
     class HasMany < Base
-      def serialize(resource)
+      def serialize_data(resource)
         {
-          serialized_name => {
-            data: relationship_from(resource).map do |relationship|
-              identifier.serialize(relationship)
-            end
-          }
+          data: relationship_from(resource).map do |relationship|
+            identifier.serialize(relationship)
+          end
         }
       end
 

--- a/lib/json_api_object_serializer/relationships/has_one.rb
+++ b/lib/json_api_object_serializer/relationships/has_one.rb
@@ -3,10 +3,10 @@
 module JsonApiObjectSerializer
   module Relationships
     class HasOne < Base
-      def serialize(resource)
+      def serialize_data(resource)
         relationship = relationship_from(resource)
 
-        { serialized_name => { data: identifier.serialize(relationship) } }
+        { data: identifier.serialize(relationship) }
       end
     end
   end

--- a/lib/json_api_object_serializer/serialization.rb
+++ b/lib/json_api_object_serializer/serialization.rb
@@ -38,9 +38,7 @@ module JsonApiObjectSerializer
     end
 
     def serialized_links(resource)
-      return {} if link_collection.empty?
-
-      { links: link_collection.serialize(resource) }
+      link_collection.serialize(resource)
     end
 
     def serialized_data(resource, fieldset:, collection:)

--- a/spec/integration/relationships/links_spec.rb
+++ b/spec/integration/relationships/links_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe "Relationship Links", type: :integration do
+  subject(:serializer) do
+    Class.new do
+      include JsonApiObjectSerializer
+
+      type "foos"
+      attribute :foo
+
+      has_many :bars, type: "bars" do
+        links do
+          simple(:self) { |_resource| "/foos/1/relationships/bars" }
+          simple(:related) { |_resource| "/foos/1/bars" }
+        end
+      end
+
+      has_one :buz, type: "buzes" do
+        links do
+          compound :related do
+            href { |resource| "/foos/1/relationships/buz/#{resource.id}" }
+            meta { |_resource| { useful: false } }
+          end
+        end
+      end
+    end
+  end
+
+  it "serializes the relationship with their links" do
+    bars_relationships = [double(:bar1, id: 1), double(:bar2, id: 2)]
+    buz_relationship = double(:buz, id: 1)
+    resource = double(:resource, id: 1, foo: "Foo", bars: bars_relationships, buz: buz_relationship)
+
+    result = serializer.to_hash(resource)
+
+    aggregate_failures do
+      expect(result).to match_jsonapi_schema
+      expect(result).to match(
+        data: a_hash_including(
+          relationships: a_hash_including(
+            bars: a_hash_including(
+              links: {
+                self: "/foos/1/relationships/bars",
+                related: "/foos/1/bars"
+              }
+            ),
+            buz: a_hash_including(
+              links: {
+                related: {
+                  href: "/foos/1/relationships/buz/1",
+                  meta: { useful: false }
+                }
+              }
+            )
+          )
+        )
+      )
+    end
+  end
+end

--- a/spec/json_api_object_serializer/link_collection_spec.rb
+++ b/spec/json_api_object_serializer/link_collection_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe JsonApiObjectSerializer::LinkCollection do
       resource = double(:resource)
 
       expect(link_collection.serialize(resource)).to eq(
-        foo: "foo_link",
-        bar: {
-          href: "bar_link",
-          meta: { meta_key: "meta_value" }
+        links: {
+          foo: "foo_link",
+          bar: {
+            href: "bar_link",
+            meta: { meta_key: "meta_value" }
+          }
         }
       )
     end

--- a/spec/json_api_object_serializer/null_link_collection_spec.rb
+++ b/spec/json_api_object_serializer/null_link_collection_spec.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiObjectSerializer::NullLinkCollection do
-  describe "#empty?" do
-    subject(:null_link_collection) { JsonApiObjectSerializer::NullLinkCollection.new }
+  subject(:null_link_collection) { JsonApiObjectSerializer::NullLinkCollection.new }
 
+  describe "#empty?" do
     it "always returns true" do
       expect(null_link_collection.empty?).to be true
+    end
+  end
+
+  describe "#serialize" do
+    it "always returns an empty hash" do
+      resource = double(:resource)
+
+      expect(null_link_collection.serialize(resource)).to eq({})
     end
   end
 end

--- a/spec/json_api_object_serializer/relationships/has_many_spec.rb
+++ b/spec/json_api_object_serializer/relationships/has_many_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe JsonApiObjectSerializer::Relationships::HasMany do
     JsonApiObjectSerializer::Relationships::HasMany.new(name: :foo_bar, type: "foos")
   end
 
-  describe "#serialize" do
-    it "returns the serialized hash of this relationship for the given resource object" do
+  describe "#serialize_data" do
+    it "returns the serialized data hash of this relationship for the given resource object" do
       foo_bar_relationship = [double(:foo_bar1, id: 1), double(:foo_bar2, id: 2)]
       resource = double(:resource, foo_bar: foo_bar_relationship)
 
-      expect(relationship.serialize(resource)).to eq(
-        "foo-bar": { data: [{ id: "1", type: "foos" }, { id: "2", type: "foos" }] }
+      expect(relationship.serialize_data(resource)).to eq(
+        data: [{ id: "1", type: "foos" }, { id: "2", type: "foos" }]
       )
     end
   end

--- a/spec/json_api_object_serializer/relationships/has_one_spec.rb
+++ b/spec/json_api_object_serializer/relationships/has_one_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe JsonApiObjectSerializer::Relationships::HasOne do
     JsonApiObjectSerializer::Relationships::HasOne.new(name: :foo_bar, type: "foos")
   end
 
-  describe "#serialize" do
-    it "returns the serialized hash of this relationship of the given resource object" do
+  describe "#serialize_data" do
+    it "returns the serialized data hash of this relationship of the given resource object" do
       foo_bar_relationship = double(:foo_bar, id: 1)
       resource = double(:resource, foo_bar: foo_bar_relationship)
 
-      expect(relationship.serialize(resource)).to eq(
-        "foo-bar": { data: { id: "1", type: "foos" } }
+      expect(relationship.serialize_data(resource)).to eq(
+        data: { id: "1", type: "foos" }
       )
     end
   end

--- a/spec/support/shared_examples/relationship_object.rb
+++ b/spec/support/shared_examples/relationship_object.rb
@@ -3,12 +3,36 @@
 RSpec.shared_examples "a relationship object" do
   it_behaves_like "a class with serialized name", name: :foo_bar, type: "foos"
 
-  it "sets the correct relationship identifier" do
-    relationship = described_class.new(name: :foo, type: "foos")
+  describe "#initialize" do
+    it "sets the correct relationship identifier" do
+      relationship = described_class.new(name: :foo, type: "foos")
 
-    aggregate_failures do
-      expect(relationship.identifier).to be_an_instance_of JsonApiObjectSerializer::Identifier
-      expect(relationship.identifier.type).to eq "foos"
+      aggregate_failures do
+        expect(relationship.identifier).to be_an_instance_of JsonApiObjectSerializer::Identifier
+        expect(relationship.identifier.type).to eq "foos"
+      end
+    end
+
+    context "with block given" do
+      subject(:relationship) do
+        described_class.new(name: :foo, type: "foos") do
+          links do
+            simple(:self) { |_resource| "simple_link" }
+            compound(:related) do
+              href { |_resource| "href_link" }
+              meta { |_resource| { meta: "hash" } }
+            end
+          end
+        end
+      end
+
+      it "sets builds the link collection correctly" do
+        aggregate_failures do
+          expect(relationship.link_collection)
+            .to be_an_instance_of JsonApiObjectSerializer::LinkCollection
+          expect(relationship.link_collection.size).to eq 2
+        end
+      end
     end
   end
 
@@ -33,6 +57,50 @@ RSpec.shared_examples "a relationship object" do
 
       expect(relationship.hash).not_to eq other_different_relationship.hash
       expect(relationship.hash).to eq other_equal_relationship.hash
+    end
+  end
+
+  describe "#serialize" do
+    context "with links" do
+      subject(:relationship) do
+        described_class.new(name: :foo, type: "foos") do
+          links do
+            simple(:self) { |_resource| "simple_link" }
+            compound(:related) do
+              href { |_resource| "href_link" }
+              meta { |_resource| { meta: "hash" } }
+            end
+          end
+        end
+      end
+
+      it "serializes the relationship data with its links" do
+        resource = double(:resource).as_null_object
+
+        expect(relationship.serialize(resource)).to match(
+          foo: a_hash_including(
+            links: {
+              self: "simple_link",
+              related: {
+                href: "href_link",
+                meta: { meta: "hash" }
+              }
+            }
+          )
+        )
+      end
+    end
+
+    context "without links" do
+      subject(:relationship) { described_class.new(name: :foo_bar, type: "foos") }
+
+      it "serializes only the relationship data" do
+        resource = double(:resource).as_null_object
+
+        result = relationship.serialize(resource)
+
+        expect(result[:"foo-bar"]).not_to include(:links)
+      end
     end
   end
 


### PR DESCRIPTION
- Adds block acceptance when declaring relationships, used to define links just like resource links
- Some simplifications on serializing relationships and link collections