### PR TITLE
Add support for deep relationship inclusion

### DIFF
--- a/lib/json_api_object_serializer/attribute_collection.rb
+++ b/lib/json_api_object_serializer/attribute_collection.rb
@@ -7,16 +7,20 @@ module JsonApiObjectSerializer
   class AttributeCollection
     extend Forwardable
 
-    def_delegators :attributes, :add
+    def_delegators :attributes, :add, :empty?
 
     def initialize
       @attributes = Set.new
     end
 
     def serialize(resource, fieldset: NullFieldset.new)
-      attributes_from(fieldset).inject({}) do |hash, attribute|
+      return {} if empty?
+
+      serialized_attributes = attributes_from(fieldset).inject({}) do |hash, attribute|
         hash.merge(attribute.serialize(resource))
       end
+
+      serialized_attributes.empty? ? {} : { attributes: serialized_attributes }
     end
 
     private

--- a/lib/json_api_object_serializer/included_resource.rb
+++ b/lib/json_api_object_serializer/included_resource.rb
@@ -2,15 +2,22 @@
 
 module JsonApiObjectSerializer
   class IncludedResource
-    attr_reader :relationship
+    attr_reader :relationship, :includings
 
-    def initialize(relationship)
+    def initialize(relationship, deep_including = nil)
       @relationship = relationship
+      @includings = deep_including.nil? ? [] : [deep_including.to_sym]
     end
 
     def serialize(resource, fieldset: NullFieldset.new)
-      serialized_hash = relationship.fully_serialize(resource, fieldset: fieldset)
-      serialized_hash.delete(:data)
+      serialized_hash =
+        relationship.fully_serialize(resource, fieldset: fieldset, including: includings)
+
+      if serialized_hash.key?(:included)
+        [serialized_hash[:data], serialized_hash[:included]].flatten
+      else
+        serialized_hash[:data]
+      end
     end
   end
 end

--- a/lib/json_api_object_serializer/included_resource_collection.rb
+++ b/lib/json_api_object_serializer/included_resource_collection.rb
@@ -7,22 +7,51 @@ module JsonApiObjectSerializer
   class IncludedResourceCollection
     extend Forwardable
 
-    def_delegators :included_resources, :add, :empty?
+    def_delegators :included_resources, :add, :empty?, :size
+
+    def self.build(includes, relationship_collection)
+      new.tap do |collection|
+        includes.each do |to_include|
+          relationship_name, deep_including = to_include.to_s.split(".", 2)
+          relationship = relationship_collection.find_by_serialized_name(relationship_name)
+
+          collection.add(IncludedResource.new(relationship, deep_including))
+        end
+      end
+    end
 
     def initialize
       @included_resources = Set.new
     end
 
-    def serialize(resource, fieldset: NullFieldset.new)
-      included = included_resources.map do |included_resource|
-        included_resource.serialize(resource, fieldset: fieldset)
-      end.flatten
+    def serialize(resource, fieldset: NullFieldset.new, collection: false)
+      return {} if empty?
 
-      included.uniq { |hash| hash.values_at(:type, :id) }
+      included_data =
+        if collection
+          serialize_for_resource_collection(resource, fieldset)
+        else
+          serialize_for_resource(resource, fieldset)
+        end
+
+      { included: included_data.uniq { |hash| hash.values_at(:type, :id) } }
     end
 
     private
 
     attr_reader :included_resources
+
+    def serialize_for_resource(resource, fieldset)
+      included_resources.map do |included_resource|
+        included_resource.serialize(resource, fieldset: fieldset)
+      end.flatten
+    end
+
+    def serialize_for_resource_collection(resource_collection, fieldset)
+      Array(resource_collection)
+        .map { |resource| serialize_for_resource(resource, fieldset) }
+        .compact
+        .flatten
+    end
   end
 end

--- a/lib/json_api_object_serializer/links/compound.rb
+++ b/lib/json_api_object_serializer/links/compound.rb
@@ -30,7 +30,7 @@ module JsonApiObjectSerializer
 
       def serialized_meta(resource)
         meta_hash = meta_blk.call(resource)
-        { meta: Meta.new(meta_hash).serialize }
+        Meta.new(meta_hash).serialize
       end
     end
   end

--- a/lib/json_api_object_serializer/meta.rb
+++ b/lib/json_api_object_serializer/meta.rb
@@ -17,7 +17,9 @@ module JsonApiObjectSerializer
     end
 
     def serialize
-      hash.deep_transform_keys { |key| serialized_key(key) }
+      return {} if empty?
+
+      { meta: hash.deep_transform_keys { |key| serialized_key(key) } }
     end
 
     def add(other_hash = {})

--- a/lib/json_api_object_serializer/relationship_collection.rb
+++ b/lib/json_api_object_serializer/relationship_collection.rb
@@ -14,12 +14,18 @@ module JsonApiObjectSerializer
     end
 
     def serialize(resource_object, fieldset: NullFieldset.new)
-      relationships_from(fieldset).inject({}) do |hash, relationship|
+      return {} if empty?
+
+      serialized_relationships = relationships_from(fieldset).inject({}) do |hash, relationship|
         hash.merge(relationship.serialize(resource_object))
       end
+
+      serialized_relationships.empty? ? {} : { relationships: serialized_relationships }
     end
 
-    def find_by_serialized_name(serialized_name)
+    def find_by_serialized_name(name)
+      serialized_name = name.to_sym
+
       relationships.find { |relationship| relationship.serialized_name == serialized_name }
     end
 

--- a/lib/json_api_object_serializer/relationships/base.rb
+++ b/lib/json_api_object_serializer/relationships/base.rb
@@ -20,9 +20,13 @@ module JsonApiObjectSerializer
         { serialized_name => serialize_data(resource).merge(serialize_links(resource)) }
       end
 
-      def fully_serialize(resource, fieldset: NullFieldset.new)
+      def fully_serialize(resource, fieldset: NullFieldset.new, including: [])
         relationship = relationship_from(resource)
-        serializer.to_hash(relationship, fully_serialize_options.merge(fields: fieldset.all_fields))
+
+        serializer.to_hash(
+          relationship,
+          fully_serialize_options.merge(fields: fieldset.all_fields, include: including)
+        )
       end
 
       def relationship_from(resource)

--- a/spec/integration/relationships/compound_documents_spec.rb
+++ b/spec/integration/relationships/compound_documents_spec.rb
@@ -1,86 +1,184 @@
 # frozen_string_literal: true
 
 RSpec.describe "Compound documents", type: :integration do
-  class UserSerializer
-    include JsonApiObjectSerializer
-
-    type "people"
-    attributes :first_name, :last_name
-    has_many :articles, type: "articles"
-    has_many :comments, type: "comments"
-  end
-
-  class CommentSerializer
-    include JsonApiObjectSerializer
-
-    type "comments"
-    attribute :body
-    has_one :user, as: :author, type: "people"
-    has_one :article, type: "articles"
-  end
-
-  subject(:article_serializer) do
-    Class.new do
+  context "shallow include" do
+    class UserSerializer
       include JsonApiObjectSerializer
 
-      type "articles"
-      attributes :title, :body
-      has_one :user, as: :author, type: "people", serializer: UserSerializer
-      has_many :comments, type: "comments", serializer: CommentSerializer
+      type "people"
+      attributes :first_name, :last_name
+      has_many :articles, type: "articles"
+      has_many :comments, type: "comments"
+    end
+
+    class CommentSerializer
+      include JsonApiObjectSerializer
+
+      type "comments"
+      attribute :body
+      has_one :user, as: :author, type: "people"
+      has_one :article, type: "articles"
+    end
+
+    subject(:article_serializer) do
+      Class.new do
+        include JsonApiObjectSerializer
+
+        type "articles"
+        attributes :title, :body
+        has_one :user, as: :author, type: "people", serializer: UserSerializer
+        has_many :comments, type: "comments", serializer: CommentSerializer
+      end
+    end
+
+    it "serializes the object correctly, including the addtional compound documents" do
+      article_author =
+        double(:article_author, id: 1, first_name: "Alexandre", last_name: "Saldanha")
+      first_comment_author =
+        double(:first_comment_author, id: 2, first_name: "Nathália", last_name: "Oliveira")
+      first_comment =
+        double(:first_comment, id: 1, body: "Comment 1 Body", user: first_comment_author)
+      second_comment = double(:second_comment, id: 2, body: "Comment 2 Body", user: article_author)
+      article = double(
+        :article, id: 1, user: article_author, title: "Title",
+                  body: "Article body", comments: [first_comment, second_comment]
+      )
+
+      # circular dependency
+      allow(article_author).to receive(:articles).and_return([article])
+      allow(article_author).to receive(:comments).and_return([second_comment])
+      allow(first_comment_author).to receive(:comments).and_return([first_comment])
+      allow(first_comment).to receive(:article).and_return(article)
+      allow(second_comment).to receive(:article).and_return(article)
+
+      result = article_serializer.to_hash(article, include: %i[author comments])
+
+      aggregate_failures do
+        expect(result).to match_jsonapi_schema
+        expect(result).to match(
+          a_hash_including(
+            included: contain_exactly(
+              {
+                id: "1", type: "people",
+                attributes: { "first-name": "Alexandre", "last-name": "Saldanha" },
+                relationships: {
+                  articles: { data: [{ id: "1", type: "articles" }] },
+                  comments: { data: [{ id: "2", type: "comments" }] }
+                }
+              },
+              {
+                id: "1", type: "comments",
+                attributes: { body: "Comment 1 Body" },
+                relationships: {
+                  author: { data: { id: "2", type: "people" } },
+                  article: { data: { id: "1", type: "articles" } }
+                }
+              },
+              id: "2", type: "comments",
+              attributes: { body: "Comment 2 Body" },
+              relationships: {
+                author: { data: { id: "1", type: "people" } },
+                article: { data: { id: "1", type: "articles" } }
+              }
+            )
+          )
+        )
+      end
     end
   end
 
-  it "serializes the object correctly, including the addtional compound documents" do
-    article_author = double(:article_author, id: 1, first_name: "Alexandre", last_name: "Saldanha")
-    first_comment_author =
-      double(:first_comment_author, id: 2, first_name: "Nathália", last_name: "Oliveira")
-    first_comment =
-      double(:first_comment, id: 1, body: "Comment 1 Body", user: first_comment_author)
-    second_comment = double(:second_comment, id: 2, body: "Comment 2 Body", user: article_author)
-    article = double(
-      :article, id: 1, user: article_author, title: "Title",
-                body: "Article body", comments: [first_comment, second_comment]
-    )
+  context "deep include" do
+    class UserSerializer
+      include JsonApiObjectSerializer
 
-    # circular dependency
-    allow(article_author).to receive(:articles).and_return([article])
-    allow(article_author).to receive(:comments).and_return([second_comment])
-    allow(first_comment_author).to receive(:comments).and_return([first_comment])
-    allow(first_comment).to receive(:article).and_return(article)
-    allow(second_comment).to receive(:article).and_return(article)
+      type "people"
+      attributes :first_name, :last_name
+      has_many :articles, type: "articles"
+      has_many :comments, type: "comments"
+    end
 
-    result = article_serializer.to_hash(article, include: %i[author comments])
+    class CommentSerializer
+      include JsonApiObjectSerializer
 
-    aggregate_failures do
-      expect(result).to match_jsonapi_schema
-      expect(result).to match(
-        a_hash_including(
-          included: contain_exactly(
-            {
-              id: "1", type: "people",
-              attributes: { "first-name": "Alexandre", "last-name": "Saldanha" },
+      type "comments"
+      attribute :body
+      has_one :user, as: :author, type: "people", serializer: UserSerializer
+      has_one :article, type: "articles"
+    end
+
+    subject(:article_serializer) do
+      Class.new do
+        include JsonApiObjectSerializer
+
+        type "articles"
+        attributes :title, :body
+        has_one :user, as: :author, type: "people", serializer: UserSerializer
+        has_many :comments, type: "comments", serializer: CommentSerializer
+      end
+    end
+
+    it "serializes the resource correctly, including all the requested additional resources" do
+      article_author =
+        double(:article_author, id: 1, first_name: "Alexandre", last_name: "Saldanha")
+      first_comment_author =
+        double(:first_comment_author, id: 2, first_name: "Nathália", last_name: "Oliveira")
+      first_comment =
+        double(:first_comment, id: 1, body: "Comment 1 Body", user: first_comment_author)
+      second_comment = double(:second_comment, id: 2, body: "Comment 2 Body", user: article_author)
+      article = double(
+        :article, id: 1, user: article_author, title: "Title",
+                  body: "Article body", comments: [first_comment, second_comment]
+      )
+
+      # circular dependency
+      allow(article_author).to receive(:articles).and_return([article])
+      allow(article_author).to receive(:comments).and_return([second_comment])
+      allow(first_comment_author).to receive(:comments).and_return([first_comment])
+      allow(first_comment_author).to receive(:articles).and_return([])
+      allow(first_comment).to receive(:article).and_return(article)
+      allow(second_comment).to receive(:article).and_return(article)
+
+      result = article_serializer.to_hash(article, include: %i[author comments.author])
+
+      aggregate_failures do
+        expect(result).to match_jsonapi_schema
+        expect(result).to match(
+          a_hash_including(
+            included: contain_exactly(
+              {
+                id: "1", type: "people",
+                attributes: { "first-name": "Alexandre", "last-name": "Saldanha" },
+                relationships: {
+                  articles: { data: [{ id: "1", type: "articles" }] },
+                  comments: { data: [{ id: "2", type: "comments" }] }
+                }
+              },
+              {
+                id: "2", type: "people",
+                attributes: { "first-name": "Nathália", "last-name": "Oliveira" },
+                relationships: {
+                  articles: { data: [] },
+                  comments: { data: [{ id: "1", type: "comments" }] }
+                }
+              },
+              {
+                id: "1", type: "comments",
+                attributes: { body: "Comment 1 Body" },
+                relationships: {
+                  author: { data: { id: "2", type: "people" } },
+                  article: { data: { id: "1", type: "articles" } }
+                }
+              },
+              id: "2", type: "comments",
+              attributes: { body: "Comment 2 Body" },
               relationships: {
-                articles: { data: [{ id: "1", type: "articles" }] },
-                comments: { data: [{ id: "2", type: "comments" }] }
-              }
-            },
-            {
-              id: "1", type: "comments",
-              attributes: { body: "Comment 1 Body" },
-              relationships: {
-                author: { data: { id: "2", type: "people" } },
+                author: { data: { id: "1", type: "people" } },
                 article: { data: { id: "1", type: "articles" } }
               }
-            },
-            id: "2", type: "comments",
-            attributes: { body: "Comment 2 Body" },
-            relationships: {
-              author: { data: { id: "1", type: "people" } },
-              article: { data: { id: "1", type: "articles" } }
-            }
+            )
           )
         )
-      )
+      end
     end
   end
 end

--- a/spec/json_api_object_serializer/attribute_collection_spec.rb
+++ b/spec/json_api_object_serializer/attribute_collection_spec.rb
@@ -4,52 +4,75 @@ RSpec.describe JsonApiObjectSerializer::AttributeCollection do
   subject(:attribute_collection) { JsonApiObjectSerializer::AttributeCollection.new }
 
   describe "#serialize" do
-    context "with no field restriction" do
-      it "returns the serialized hash of all attributes of the given resource object" do
+    context "when collection is empty" do
+      it "returns an empty hash" do
         resource = double(:resource)
-        first_name_attribute = instance_double(
-          JsonApiObjectSerializer::Attribute,
-          serialized_name: :"first-name",
-          serialize: { "first-name": "Alexandre" }
-        )
-        last_name_attribute = instance_double(
-          JsonApiObjectSerializer::Attribute,
-          serialized_name: :"last-name",
-          serialize: { "last-name": "Saldanha" }
-        )
 
-        attribute_collection.add(first_name_attribute)
-        attribute_collection.add(last_name_attribute)
-
-        expect(attribute_collection.serialize(resource)).to match(
-          "first-name": "Alexandre", "last-name": "Saldanha"
-        )
+        expect(attribute_collection.serialize(resource)).to eq({})
       end
     end
 
-    context "with field restriction" do
-      it "returns the serialized hash of the specified attributes of the given resource object" do
-        resource = double(:resource)
-        fieldset = instance_double(JsonApiObjectSerializer::Fieldset)
-        first_name_attribute = instance_double(
-          JsonApiObjectSerializer::Attribute,
-          serialize: { "first-name": "Alexandre" },
-          serialized_name: :"first-name"
-        )
-        last_name_attribute = instance_double(
-          JsonApiObjectSerializer::Attribute,
-          serialized_name: :"last-name"
-        )
+    context "when collection is not empty" do
+      context "and some field restriction is applied" do
+        let(:first_name_attribute) do
+          instance_double(
+            JsonApiObjectSerializer::Attribute,
+            serialized_name: :"first-name",
+            serialize: { "first-name": "Alexandre" }
+          )
+        end
 
-        allow(fieldset).to receive(:include?).with(:"first-name").and_return(true)
-        allow(fieldset).to receive(:include?).with(:"last-name").and_return(false)
+        let(:last_name_attribute) do
+          instance_double(
+            JsonApiObjectSerializer::Attribute,
+            serialized_name: :"last-name"
+          )
+        end
 
-        attribute_collection.add(first_name_attribute)
-        attribute_collection.add(last_name_attribute)
+        before do
+          attribute_collection.add(first_name_attribute)
+          attribute_collection.add(last_name_attribute)
+        end
 
-        expect(attribute_collection.serialize(resource, fieldset: fieldset)).to match(
-          "first-name": "Alexandre"
-        )
+        it "returns the serialized hash of only the permitted attributes of the given resource" do
+          resource = double(:resource)
+          fieldset = instance_double(JsonApiObjectSerializer::Fieldset)
+
+          allow(fieldset).to receive(:include?).with(:"first-name").and_return(true)
+          allow(fieldset).to receive(:include?).with(:"last-name").and_return(false)
+
+          expect(attribute_collection.serialize(resource, fieldset: fieldset)).to eq(
+            attributes: { "first-name": "Alexandre" }
+          )
+        end
+      end
+
+      context "and field restriction is applied to all attributes" do
+        let(:first_name_attribute) do
+          instance_double(
+            JsonApiObjectSerializer::Attribute,
+            serialized_name: :"first-name"
+          )
+        end
+
+        let(:last_name_attribute) do
+          instance_double(
+            JsonApiObjectSerializer::Attribute,
+            serialized_name: :"last-name"
+          )
+        end
+
+        before do
+          attribute_collection.add(first_name_attribute)
+          attribute_collection.add(last_name_attribute)
+        end
+
+        it "returns an empty hash" do
+          resource = double(:resource)
+          fieldset = instance_double(JsonApiObjectSerializer::Fieldset, include?: false)
+
+          expect(attribute_collection.serialize(resource, fieldset: fieldset)).to eq({})
+        end
       end
     end
   end

--- a/spec/json_api_object_serializer/included_resource_collection_spec.rb
+++ b/spec/json_api_object_serializer/included_resource_collection_spec.rb
@@ -1,43 +1,75 @@
 # frozen_string_literal: true
 
 RSpec.describe JsonApiObjectSerializer::IncludedResourceCollection do
+  describe ".build" do
+    it "builds a new collection correctly" do
+      relationship_collection = instance_double(JsonApiObjectSerializer::RelationshipCollection)
+      allow(relationship_collection)
+        .to receive(:find_by_serialized_name)
+        .twice.and_return(double(:relationship1), double(:relationship2))
+
+      collection = JsonApiObjectSerializer::IncludedResourceCollection.build(
+        %i[foo bar.baz], relationship_collection
+      )
+
+      aggregate_failures do
+        expect(collection).to be_an_instance_of JsonApiObjectSerializer::IncludedResourceCollection
+        expect(collection.size).to eq 2
+      end
+    end
+  end
+
   describe "#serialize" do
-    let(:included_resource1) do
-      instance_double(
-        JsonApiObjectSerializer::IncludedResource,
-        serialize: {
-          id: "1", type: "foos", attributes: { foo: "Foo" }
-        }
-      )
+    context "when the collection is empty" do
+      subject(:included_collection) { JsonApiObjectSerializer::IncludedResourceCollection.new }
+
+      it "returns an empty hash" do
+        resource = double(:resource)
+
+        expect(included_collection.serialize(resource)).to eq({})
+      end
     end
 
-    let(:included_resource2) do
-      instance_double(
-        JsonApiObjectSerializer::IncludedResource,
-        serialize: [
-          { id: "1", type: "bars", attributes: { bar: "Bar 1" } },
-          { id: "2", type: "bars", attributes: { bar: "Bar 2" } }
-        ]
-      )
-    end
+    context "when the collection is not empty" do
+      let(:included_resource1) do
+        instance_double(
+          JsonApiObjectSerializer::IncludedResource,
+          serialize: {
+            id: "1", type: "foos", attributes: { foo: "Foo" }
+          }
+        )
+      end
 
-    subject(:included_resource_collection) do
-      JsonApiObjectSerializer::IncludedResourceCollection.new
-    end
+      let(:included_resource2) do
+        instance_double(
+          JsonApiObjectSerializer::IncludedResource,
+          serialize: [
+            { id: "1", type: "bars", attributes: { bar: "Bar 1" } },
+            { id: "2", type: "bars", attributes: { bar: "Bar 2" } }
+          ]
+        )
+      end
 
-    before do
-      included_resource_collection.add(included_resource1)
-      included_resource_collection.add(included_resource2)
-    end
+      subject(:included_resource_collection) do
+        JsonApiObjectSerializer::IncludedResourceCollection.new
+      end
 
-    it "returns an array with the serialized included resources" do
-      resource = double(:resource)
+      before do
+        included_resource_collection.add(included_resource1)
+        included_resource_collection.add(included_resource2)
+      end
 
-      expect(included_resource_collection.serialize(resource)).to contain_exactly(
-        { id: "1", type: "foos", attributes: { foo: "Foo" } },
-        { id: "1", type: "bars", attributes: { bar: "Bar 1" } },
-        id: "2", type: "bars", attributes: { bar: "Bar 2" }
-      )
+      it "returns the serialized hash of the collection" do
+        resource = double(:resource)
+
+        expect(included_resource_collection.serialize(resource)).to eq(
+          included: [
+            { id: "1", type: "foos", attributes: { foo: "Foo" } },
+            { id: "1", type: "bars", attributes: { bar: "Bar 1" } },
+            { id: "2", type: "bars", attributes: { bar: "Bar 2" } }
+          ]
+        )
+      end
     end
   end
 end

--- a/spec/json_api_object_serializer/included_resource_spec.rb
+++ b/spec/json_api_object_serializer/included_resource_spec.rb
@@ -2,23 +2,51 @@
 
 RSpec.describe JsonApiObjectSerializer::IncludedResource do
   describe "#serialize" do
-    it "returns the fully serialized hash of the resource relationship" do
-      resource = double(:resource)
-      relationship = instance_double(
-        JsonApiObjectSerializer::Relationships::Base,
-        fully_serialize: {
-          data: {
-            id: "1", type: "foos", attributes: { foo: "Foo", bar: "Bar" },
-            relationships: { bar: { data: { id: "1", type: "bars" } } }
+    context "when the serialization uses including resources" do
+      it "retruns the fully serialized hash with its included resources" do
+        resource = double(:resource)
+        relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          fully_serialize: {
+            data: [
+              { id: "1", type: "foos", attributes: { foo: "Foo" } },
+              { id: "2", type: "foos", attributes: { foo: "Fus" } }
+            ],
+            included: [
+              { id: "1", type: "bars", attributes: { bar: "Bar" } }
+            ]
           }
-        }
-      )
-      included_resource = JsonApiObjectSerializer::IncludedResource.new(relationship)
+        )
 
-      expect(included_resource.serialize(resource)).to eq(
-        id: "1", type: "foos", attributes: { foo: "Foo", bar: "Bar" },
-        relationships: { bar: { data: { id: "1", type: "bars" } } }
-      )
+        included_resource = JsonApiObjectSerializer::IncludedResource.new(relationship, "bar")
+
+        expect(included_resource.serialize(resource)).to contain_exactly(
+          { id: "1", type: "foos", attributes: { foo: "Foo" } },
+          { id: "2", type: "foos", attributes: { foo: "Fus" } },
+          id: "1", type: "bars", attributes: { bar: "Bar" }
+        )
+      end
+    end
+
+    context "when the serialization doesn't include any other resource" do
+      it "returns the fully serialized hash of the resource relationship" do
+        resource = double(:resource)
+        relationship = instance_double(
+          JsonApiObjectSerializer::Relationships::Base,
+          fully_serialize: {
+            data: {
+              id: "1", type: "foos", attributes: { foo: "Foo", bar: "Bar" },
+              relationships: { bar: { data: { id: "1", type: "bars" } } }
+            }
+          }
+        )
+        included_resource = JsonApiObjectSerializer::IncludedResource.new(relationship)
+
+        expect(included_resource.serialize(resource)).to eq(
+          id: "1", type: "foos", attributes: { foo: "Foo", bar: "Bar" },
+          relationships: { bar: { data: { id: "1", type: "bars" } } }
+        )
+      end
     end
   end
 end

--- a/spec/json_api_object_serializer/meta_spec.rb
+++ b/spec/json_api_object_serializer/meta_spec.rb
@@ -12,9 +12,22 @@ RSpec.describe JsonApiObjectSerializer::Meta do
   end
 
   describe "#serialize" do
-    it "returns the serialized inner hash" do
-      meta.add(foo: "foo", fuz_bar: "fuz-bar", bar: { "fuz" => "fuz" })
-      expect(meta.serialize).to eq(foo: "foo", "fuz-bar": "fuz-bar", bar: { fuz: "fuz" })
+    context "when it is empty" do
+      it "returns an empty hash" do
+        expect(meta.serialize).to eq({})
+      end
+    end
+
+    context "when it is not empty" do
+      before do
+        meta.add(foo: "foo", fuz_bar: "fuz-bar", bar: { "fuz" => "fuz" })
+      end
+
+      it "returns the serialized inner hash" do
+        expect(meta.serialize).to eq(
+          meta: { foo: "foo", "fuz-bar": "fuz-bar", bar: { fuz: "fuz" } }
+        )
+      end
     end
   end
 end

--- a/spec/support/shared_examples/relationship_object.rb
+++ b/spec/support/shared_examples/relationship_object.rb
@@ -117,7 +117,7 @@ RSpec.shared_examples "a relationship object" do
 
       subject.fully_serialize(resource)
       expect(relationship_serializer).to have_received(:to_hash)
-        .with(foo_relationship, a_hash_including(fields: {}))
+        .with(foo_relationship, a_hash_including(fields: {}, include: []))
     end
   end
 end


### PR DESCRIPTION
- Add support for deep relationship inclusion when the `include` options contain values with dot (e.g. `include: %i[comments.author]`)
- Some code refactoring of collection classes serialization